### PR TITLE
Allow input#hashResult focus on Firefox

### DIFF
--- a/views/index.php
+++ b/views/index.php
@@ -42,7 +42,7 @@
               <input autofocus type="text" class="form-control" id="stringToHash" name="stringToHash" placeholder="Enter string to bcrypt..."/>
             </div>   
             <div class="form-group">
-              <input disabled type="text" class="form-control" id="hashResult" value="<?php echo $hashResult;?>">
+              <input readonly type="text" class="form-control" id="hashResult" value="<?php echo $hashResult;?>">
             </div>      
             <button type="submit" class="btn btn-default btn-sm">Submit</button>    
           </form>


### PR DESCRIPTION
Using disabled attribute of input fields prevents users from focusing the field, which prevents from copying the hash.
Fixed it using the readonly attribute instead